### PR TITLE
_html_to_odicts typo: s/recursive-False/recursive=False

### DIFF
--- a/data_dispenser/sources.py
+++ b/data_dispenser/sources.py
@@ -207,7 +207,7 @@ def _html_to_odicts(html, *args, **kwargs):
     if (tbl.thead or tbl).tr.th:
         headers = [th.text for th in (tbl.thead or tbl).tr.find_all('th', recursive=False)]
     else:
-        headers = [td.text for td in (tbl.tbody or tbl).tr.find_all('td', recursive-False)]
+        headers = [td.text for td in (tbl.tbody or tbl).tr.find_all('td', recursive=False)]
     for (col_num, header) in enumerate(headers):
         header = header or "Field%d" % (col_num + 1)
     for tr in (tbl.tbody or tbl).find_all('tr', recursive=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ pymongo>=2.7
 pyyaml>=3.11
 requests>=2.3
 xlrd>=0.9.3
+beautifulsoup4
 


### PR DESCRIPTION
HTML files that have tables without header rows or "th" tags fail to load.
